### PR TITLE
fix(typos): fixed up category names in the 03-costs post (mostly)

### DIFF
--- a/blogs/finance/posts/03-costs.md
+++ b/blogs/finance/posts/03-costs.md
@@ -47,8 +47,8 @@ Let's work through an example step by step. Individual expenses are highly varia
 - housing
 - food and groceries
 - transportation
-- Personal
-- Household
+- personal upkeep
+- household upkeep
 - subscriptions and memberships
 - hobbies
 - miscellaneous costs
@@ -91,7 +91,7 @@ However, when living near New York City, bus fares and train tickets _are_ a mor
 
 One last point: if you _do_ own a car, you will almost certainly be paying monthly **car insurance**. Additionally, if the car was financed, you'll have monthly **loan payments**. As we can see, what we wrote is completely different from the description preceding the table. There is a strong degree of versatility available per category, but the key is to remain honest.
 
-### Personal
+### Personal upkeep
 
 As the name of the category suggests, the expenses therein exhibit a high degree of variegation. Most people probably spend some amount of money on **clothing** per year for sure (including outerwear such as jackets or shoes). Then, there are products used for **personal grooming** (such as deodorant, hair products, makeup, nails, body soap, shampoo and conditioner, etc.) which are likely monthly purchases. This leads to a relatively simple chart:
 
@@ -107,9 +107,9 @@ As for self-care products... it's hard to say. I'm not the type to set up recurr
 
 By the way, if you take **medicine** or buy multivitamins, it's worth including them here too. I try pretty hard to avoid any unnecessary medication, so this is empty for me for now. You'll also notice that I haven't included any dentist fees, doctor's visits, or emergency room fees. At the moment, I'm fortunte to be in good health and have nearly zero costs per year. However, I do still have to submit a co-pay for annual checkups and the like. This is handled via a combination of insurance and a health savings account (HSA). We'll discuss this in great detail later on, but in terms of out-of-pocket costs I don't pay anything for **healthcare**, as insurance from my employer covers the usual.
 
-### Household
+### Household upkeep
 
-Unlike Personal, Household refers to the products that are not related to personal care. For example, some items might include **Cleaning** (such as Lysol, Swiffer, mops, brooms), **Washing** (hand soap, dish soap), **laundry** (Tide pods, dryer sheets, fabric softener, potentially quarters), and **fabrics** (hand towels, face towels, bedsheets need to all be replaced about once a year). It's important to include lightbulbs, garbage liners, and maybe water bottles under a broader **Homeliness** umbrella. And so another chart arrives:
+Unlike personal upkeep, household upkeep refers to the products that are not related to personal care. For example, some items might include **cleaning supplies** (such as Lysol, Swiffer, mops, brooms), **washing supplies** (hand soap, dish soap), **laundry** (Tide pods, dryer sheets, fabric softener, potentially quarters), and **fabrics** (hand towels, face towels, bedsheets need to all be replaced about once a year). It's important to include lightbulbs, garbage liners, and maybe water bottles under a broader **homeliness** umbrella. And so another chart arrives:
 
 {:.mono-table}
 | Item | Category | $/wk | $/mo | $/yr |
@@ -122,11 +122,11 @@ Unlike Personal, Household refers to the products that are not related to person
 
 Wow, there are a lot of hidden costs to living! It's not just the sticker price on the apartment, condo, townhouse, or single-family home -- these maintenance costs really add up. One of the common ways to remain frugal is to cut back on the maintenance costs, but I'd personally advise against it. I'd rather live someplace with a cheaper month-to-month rent but still maintain a clean, fresh living environment.
 
-Some folks instead elect to pay for a **cleaning service**. Usually I've seen these cost around $\\$125$ for a once-a-month visit. This is pretty expensive in my opinion, so I clean my place myself. It's possible that the cleaning service may bring some of their own Cleaning, but nonetheless you'd probably still maintain your own supplies for laundry, fabrics, etc.
+Some folks instead elect to pay for a **cleaning service**. Usually I've seen these cost around $\\$125$ for a once-a-month visit. This is pretty expensive in my opinion, so I clean my place myself. It's possible that the cleaning service may bring some of their own cleaning supplies, but nonetheless you'd probably still maintain your own supplies for laundry, fabrics, etc.
 
 ### Subscriptions and memberships
 
-Ah, yes. There's [no doubt][gen-z] that younger folks maintain a variety of digital memberships in their portfolio. The subscription economy can be quite expensive, and it's very important to track these costs. Amazon Prime, Netflix, Hulu, HBO, Disney+, AppleTV... the list goes on. **Subscriptions** are going to be an important part of costs. Similarly, **memberships** form the other half of these core (monthly) recurring expenses. For example, a Gym fees or a country club membership would also count. Here's my chart, using sticker prices:
+Ah, yes. There's [no doubt][gen-z] that younger folks maintain a variety of digital memberships in their portfolio. The subscription economy can be quite expensive, and it's very important to track these costs. Amazon Prime, Netflix, Hulu, HBO, Disney+, AppleTV... the list goes on. **Subscriptions** are going to be an important part of costs. Similarly, **memberships** form the other half of these core (monthly) recurring expenses. For example, a gym membership or a country club membership would also count. Here's my chart, using sticker prices:
 
 {:.mono-table}
 | Item | Category | $/wk | $/mo | $/yr |
@@ -150,7 +150,7 @@ Actually, it turns out that this is all a lie: some subscriptions [charge sales 
 | Prime | Subscriptions | -- | -- | $148.21 |
 | _Economist_ | Subscriptions | -- | -- | $265.50 |
 
-I don't really watch any television, as most of my entertainment either comes from books, digital articles, YouTube, or board games. As a result, I don't have any subscriptions to any of the usual streaming services that are popular today. Some notable costs above include a $\\$180$ Gym fees, a Discord Nitro subscription, and a (very!) expensive subscription to _The Economist_, which probably makes up for the lack of the usual suspects -- and more.
+I don't really watch any television, as most of my entertainment either comes from books, digital articles, YouTube, or board games. As a result, I don't have any subscriptions to any of the usual streaming services that are popular today. Some notable costs above include a $\\$180$ gym membership, a Discord Nitro subscription, and a (very!) expensive subscription to _The Economist_, which probably makes up for the lack of the usual suspects -- and more.
 
 The [gym][gym] I frequent costs $\\$225$ per month, and my insurance reimburses policyholders $\\$60$ per month if they attend 12 or more times in that month. This encourages folks to (presumably) remain healthy, which in the long-term would cost the insurance company less in emergency pay-outs. As for Nitro, I do spend a [lot of time][introverts] online and derive enjoyment from the expressiveness that a premium subscription to Discord proffers. Finally, _The Economist_ is, in my opinion, one of the only truly global news troves available today. I have yet to find a suitable replacement that is more friendly on the budget, so this is one of my few splurges as a relatively frugal person. I haven't managed to find a friend with whom to split the annual subscription cost in the company I keep, but I'm always on the hunt!
 

--- a/blogs/finance/posts/04-evolution.md
+++ b/blogs/finance/posts/04-evolution.md
@@ -47,7 +47,7 @@ The other constraints on the optimization problem are merely hyperparameters; fo
 
 ## Constructing the expense sequence
 
-Obviously, it's not possible to predict so much in advance. If one's fortune changes, the requisite mending of the projections can be introduced to intervene and force the behavior to evolve in accordance with the new information. For example, if a child has an unexpected affliction, this can definitely increase the household healthcare costs. Similarly, many staunch bachelors and bachelorettes may find themselves getting married [after all][bachelors] eventually.
+Obviously, it's not possible to predict so much in advance. If one's fortune changes, the requisite mending of the data projections can be introduced to intervene and force the behavior to evolve in accordance with the new information. For example, if a child has an unexpected affliction, this can definitely increase the household healthcare costs. Similarly, many staunch bachelors and bachelorettes may find themselves getting married [after all][bachelors] eventually.
 
 With that in mind, let's construct our expected expense sequence. Like last time, I'll present each chart and provide some commentary. Luckily for readers, this time I won't do a detailed analysis by category.
 


### PR DESCRIPTION
Yeah, oops! I noticed this while casually scrolling over the weekend. Finally got around to fixing this. This is the danger of using Find + Replace!